### PR TITLE
⚡ [performance improvement] Optimize Order Number Generation

### DIFF
--- a/Boteco32/Boteco32/Context/Boteco32Context.cs
+++ b/Boteco32/Boteco32/Context/Boteco32Context.cs
@@ -113,6 +113,8 @@ namespace Boteco32.Models
 
                 entity.Property(e => e.Numero).HasColumnName("numero");
 
+                entity.HasIndex(e => e.Numero, "IX_Pedido_numero");
+
                 entity.Property(e => e.ValorTotal)
                     .HasColumnType("decimal(10, 2)")
                     .HasColumnName("valorTotal");

--- a/Boteco32/Boteco32/Repository/PedidoRepository.cs
+++ b/Boteco32/Boteco32/Repository/PedidoRepository.cs
@@ -46,8 +46,7 @@ namespace Boteco32.Repository
         {
             using (var data = new Boteco32Context(_context))
             {
-              int quant =  data.Set<Pedido>().Count();
-              return quant;
+                return (data.Set<Pedido>().Max(p => (int?)p.Numero) ?? 0) + 1;
             }                   
         }
 

--- a/Boteco32/Boteco32/Services/PedidoService.cs
+++ b/Boteco32/Boteco32/Services/PedidoService.cs
@@ -54,7 +54,7 @@ namespace Boteco32.Services
 
             novoPedido.Data = DateTime.Now.ToString();
             novoPedido.ValorTotal = total;
-            novoPedido.Numero = _pedidoRepository.GerarNumeroPedido() + 1;
+            novoPedido.Numero = _pedidoRepository.GerarNumeroPedido();
             novoPedido.IdCliente = idCliente;
 
             Pedido resultado = await _pedidoRepository.AdicionarPedido(novoPedido);

--- a/Boteco32/TestProject/PedidoRepositoryTest.cs
+++ b/Boteco32/TestProject/PedidoRepositoryTest.cs
@@ -1,0 +1,50 @@
+using System.Collections.Generic;
+using System.Linq;
+using Boteco32.Models;
+using Boteco32.Repository;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Moq;
+
+namespace TestProject
+{
+    [TestClass]
+    public class PedidoRepositoryTest
+    {
+        [TestMethod]
+        public void GerarNumeroPedido_ShouldReturnMaxNumero()
+        {
+            // Arrange
+            var data = new List<Pedido>
+            {
+                new Pedido { Numero = 1 },
+                new Pedido { Numero = 5 },
+                new Pedido { Numero = 3 }
+            }.AsQueryable();
+
+            var mockSet = new Mock<DbSet<Pedido>>();
+            mockSet.As<IQueryable<Pedido>>().Setup(m => m.Provider).Returns(data.Provider);
+            mockSet.As<IQueryable<Pedido>>().Setup(m => m.Expression).Returns(data.Expression);
+            mockSet.As<IQueryable<Pedido>>().Setup(m => m.ElementType).Returns(data.ElementType);
+            mockSet.As<IQueryable<Pedido>>().Setup(m => m.GetEnumerator()).Returns(data.GetEnumerator());
+
+            var options = new DbContextOptionsBuilder<Boteco32Context>().Options;
+            // Since PedidoRepository creates its own context in the method,
+            // this is hard to unit test without refactoring.
+            // But we can at least verify the logic of Max() on nullable int.
+
+            int? maxNumero = data.Max(p => (int?)p.Numero);
+            Assert.AreEqual(6, (maxNumero ?? 0) + 1);
+        }
+
+        [TestMethod]
+        public void GerarNumeroPedido_ShouldReturnOne_WhenEmpty()
+        {
+            // Arrange
+            var data = new List<Pedido>().AsQueryable();
+
+            int? maxNumero = data.Max(p => (int?)p.Numero);
+            Assert.AreEqual(1, (maxNumero ?? 0) + 1);
+        }
+    }
+}


### PR DESCRIPTION
💡 **What:** The optimization implemented
- Changed `GerarNumeroPedido` from using `Count()` to `Max() + 1`.
- Added an index to the `Numero` column in the database configuration.
- Refactored `PedidoService` to remove redundant increment logic.

🎯 **Why:** The performance problem it solves
- `Count()` is O(N) and requires a full table scan or counting all records, which slows down as the table grows.
- Logically, `Count()` fails to generate unique sequence numbers if records are deleted, leading to potential duplicates.
- `Max()` with an index is O(log N) and correctly handles deletions.

📊 **Measured Improvement:**
- While environment limitations prevented running full benchmarks, the theoretical improvement moves the operation from O(N) to O(log N).
- Correctness is improved by ensuring unique order numbers even after deletions.

---
*PR created automatically by Jules for task [17270140718146187590](https://jules.google.com/task/17270140718146187590) started by @allanschramm*